### PR TITLE
Option to wider configuration of the client

### DIFF
--- a/Modrinth.Net.Test/ModrinthApiTests/EndpointTests.cs
+++ b/Modrinth.Net.Test/ModrinthApiTests/EndpointTests.cs
@@ -38,8 +38,21 @@ public class EndpointTests
             ProjectName = "Modrinth.Net.Test",
             ProjectVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString()
         };
+        
+        var configAuth = new ModrinthClientConfiguration
+        {
+            ModrinthToken = token,
+            BaseUrl = ModrinthClient.StagingBaseUrl,
+            UserAgent = userAgent.ToString()
+        };
+        
+        var configNoAuth = new ModrinthClientConfiguration
+        {
+            BaseUrl = ModrinthClient.StagingBaseUrl,
+            UserAgent = userAgent.ToString()
+        };
 
-        Client = new ModrinthClient(url: ModrinthClient.StagingBaseUrl, userAgent: userAgent, token: token);
-        NoAuthClient = new ModrinthClient(url: ModrinthClient.StagingBaseUrl, userAgent: userAgent);
+        Client = new ModrinthClient(configAuth);
+        NoAuthClient = new ModrinthClient(configNoAuth);
     }
 }

--- a/Modrinth.Net.Test/ModrinthApiTests/EndpointTests.cs
+++ b/Modrinth.Net.Test/ModrinthApiTests/EndpointTests.cs
@@ -38,14 +38,14 @@ public class EndpointTests
             ProjectName = "Modrinth.Net.Test",
             ProjectVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString()
         };
-        
+
         var configAuth = new ModrinthClientConfiguration
         {
             ModrinthToken = token,
             BaseUrl = ModrinthClient.StagingBaseUrl,
             UserAgent = userAgent.ToString()
         };
-        
+
         var configNoAuth = new ModrinthClientConfiguration
         {
             BaseUrl = ModrinthClient.StagingBaseUrl,

--- a/Modrinth.Net/Http/Requester.cs
+++ b/Modrinth.Net/Http/Requester.cs
@@ -10,8 +10,6 @@ namespace Modrinth.Http;
 /// <inheritdoc />
 public class Requester : IRequester
 {
-    private ModrinthClientConfiguration _configuration;
-
     private readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
         PropertyNameCaseInsensitive = true,
@@ -22,6 +20,8 @@ public class Requester : IRequester
         }
     };
 
+    private readonly ModrinthClientConfiguration _configuration;
+
     public Requester(ModrinthClientConfiguration configuration, HttpClient? httpClient = null)
     {
         _configuration = configuration;
@@ -31,17 +31,18 @@ public class Requester : IRequester
             return;
         }
 
-        this.BaseAddress = new Uri(configuration.BaseUrl);
+        BaseAddress = new Uri(configuration.BaseUrl);
         HttpClient = new HttpClient
         {
-            BaseAddress = this.BaseAddress,
+            BaseAddress = BaseAddress,
             DefaultRequestHeaders =
             {
                 {"User-Agent", configuration.UserAgent}
             }
         };
 
-        if (!string.IsNullOrEmpty(configuration.ModrinthToken)) HttpClient.DefaultRequestHeaders.Add("Authorization", configuration.ModrinthToken);
+        if (!string.IsNullOrEmpty(configuration.ModrinthToken))
+            HttpClient.DefaultRequestHeaders.Add("Authorization", configuration.ModrinthToken);
     }
 
     /// <summary>
@@ -99,7 +100,8 @@ public class Requester : IRequester
             {
                 if (retryCount >= _configuration.RateLimitRetryCount)
                     throw new ModrinthApiException(
-                        $"Request was rate limited and retry limit ({_configuration.RateLimitRetryCount}) was reached", response.StatusCode,
+                        $"Request was rate limited and retry limit ({_configuration.RateLimitRetryCount}) was reached",
+                        response.StatusCode,
                         response.Content, null);
 
                 if (response.Headers.TryGetValues("X-Ratelimit-Reset", out var resetValues))

--- a/Modrinth.Net/Modrinth.Net.csproj
+++ b/Modrinth.Net/Modrinth.Net.csproj
@@ -13,7 +13,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageVersion>3.1.0-alpha2</PackageVersion>
-		<Version>$(PackageVersion)</Version>
+        <Version>$(PackageVersion)</Version>
         <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Modrinth</RootNamespace>
     </PropertyGroup>

--- a/Modrinth.Net/Modrinth.Net.csproj
+++ b/Modrinth.Net/Modrinth.Net.csproj
@@ -13,6 +13,7 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageVersion>3.1.0-alpha2</PackageVersion>
+		<Version>$(PackageVersion)</Version>
         <TargetFramework>net6.0</TargetFramework>
         <RootNamespace>Modrinth</RootNamespace>
     </PropertyGroup>

--- a/Modrinth.Net/ModrinthClient.cs
+++ b/Modrinth.Net/ModrinthClient.cs
@@ -26,7 +26,10 @@ public class ModrinthClient : IModrinthClient
 
     private readonly IRequester _requester;
 
+    private readonly ModrinthClientConfiguration _configuration;
+    
     /// <inheritdoc />
+    [Obsolete("Use the constructor that takes a ModrinthClientConfiguration instead")]
     public ModrinthClient(UserAgent userAgent, string? token = null, string url = BaseUrl)
         : this(userAgent.ToString(), token, url)
     {
@@ -42,12 +45,36 @@ public class ModrinthClient : IModrinthClient
     /// </param>
     /// <param name="url">Custom API url, default is <see cref="BaseUrl" /></param>
     /// <returns></returns>
-    public ModrinthClient(string userAgent, string? token = null, string url = BaseUrl)
+    [Obsolete("Use the constructor that takes a ModrinthClientConfiguration instead")]
+    public ModrinthClient(string userAgent, string? token = null, string url = BaseUrl) : this (new ModrinthClientConfiguration
     {
-        if (string.IsNullOrEmpty(userAgent))
-            throw new ArgumentException("User-Agent cannot be empty", nameof(userAgent));
+        ModrinthToken = token,
+        BaseUrl = url,
+        UserAgent = userAgent   
+    })
+    {}
+    
+    /// <summary>
+    ///   Initializes a new instance of the <see cref="ModrinthClient" /> class.
+    ///   Uses the default configuration.
+    /// </summary>
+    public ModrinthClient() : this(new ModrinthClientConfiguration())
+    {
+    }
 
-        _requester = new Requester(new Uri(url, UriKind.Absolute), userAgent, token);
+    /// <summary>
+    ///    Initializes a new instance of the <see cref="ModrinthClient" /> class.
+    /// </summary>
+    /// <param name="configuration"> Configuration for the client </param>
+    /// <param name="httpClient"> Custom <see cref="HttpClient" /> to use for requests, if null a new one will be created </param>
+    /// <exception cref="ArgumentException"> Thrown when the User-Agent is empty </exception>
+    public ModrinthClient(ModrinthClientConfiguration configuration, HttpClient? httpClient = null)
+    {
+        if (string.IsNullOrEmpty(configuration.UserAgent))
+            throw new ArgumentException("User-Agent cannot be empty", nameof(configuration.UserAgent));
+
+        _configuration = configuration;
+        _requester = new Requester(configuration, httpClient);
 
         Project = new ProjectEndpoint(_requester);
         Tag = new TagEndpoint(_requester);

--- a/Modrinth.Net/ModrinthClient.cs
+++ b/Modrinth.Net/ModrinthClient.cs
@@ -24,10 +24,10 @@ public class ModrinthClient : IModrinthClient
     /// </summary>
     public const string StagingBaseUrl = "https://staging-api.modrinth.com/v2/";
 
+    private readonly ModrinthClientConfiguration _configuration;
+
     private readonly IRequester _requester;
 
-    private readonly ModrinthClientConfiguration _configuration;
-    
     /// <inheritdoc />
     [Obsolete("Use the constructor that takes a ModrinthClientConfiguration instead")]
     public ModrinthClient(UserAgent userAgent, string? token = null, string url = BaseUrl)
@@ -46,24 +46,26 @@ public class ModrinthClient : IModrinthClient
     /// <param name="url">Custom API url, default is <see cref="BaseUrl" /></param>
     /// <returns></returns>
     [Obsolete("Use the constructor that takes a ModrinthClientConfiguration instead")]
-    public ModrinthClient(string userAgent, string? token = null, string url = BaseUrl) : this (new ModrinthClientConfiguration
+    public ModrinthClient(string userAgent, string? token = null, string url = BaseUrl) : this(
+        new ModrinthClientConfiguration
+        {
+            ModrinthToken = token,
+            BaseUrl = url,
+            UserAgent = userAgent
+        })
     {
-        ModrinthToken = token,
-        BaseUrl = url,
-        UserAgent = userAgent   
-    })
-    {}
-    
+    }
+
     /// <summary>
-    ///   Initializes a new instance of the <see cref="ModrinthClient" /> class.
-    ///   Uses the default configuration.
+    ///     Initializes a new instance of the <see cref="ModrinthClient" /> class.
+    ///     Uses the default configuration.
     /// </summary>
     public ModrinthClient() : this(new ModrinthClientConfiguration())
     {
     }
 
     /// <summary>
-    ///    Initializes a new instance of the <see cref="ModrinthClient" /> class.
+    ///     Initializes a new instance of the <see cref="ModrinthClient" /> class.
     /// </summary>
     /// <param name="configuration"> Configuration for the client </param>
     /// <param name="httpClient"> Custom <see cref="HttpClient" /> to use for requests, if null a new one will be created </param>

--- a/Modrinth.Net/ModrinthClientConfiguration.cs
+++ b/Modrinth.Net/ModrinthClientConfiguration.cs
@@ -21,12 +21,10 @@ public class ModrinthClientConfiguration
     /// User-Agent you want to use while communicating with Modrinth API, it's recommended to
     /// set a uniquely-identifying one (<a href="https://docs.modrinth.com/api-spec/#section/User-Agents">see the docs</a>)
     /// </summary>
-    public string UserAgent { get; set; } = $"Modrinth.Net/{Assembly.GetExecutingAssembly().GetName().Version}";
+    public string UserAgent { get; set; } = $"Modrinth.Net/{ PackageVersion.GetVersion() }";
 
     /// <summary>
     ///   The number of times to retry a request if the rate limit is hit
     /// </summary>
     public int RateLimitRetryCount { get; set; } = 5;
-    
-    
 }

--- a/Modrinth.Net/ModrinthClientConfiguration.cs
+++ b/Modrinth.Net/ModrinthClientConfiguration.cs
@@ -1,0 +1,32 @@
+﻿using System.Reflection;
+
+namespace Modrinth;
+
+/// <summary>
+///    Object containing configuration for <see cref="ModrinthClient"/>
+/// </summary>
+public class ModrinthClientConfiguration
+{
+    /// <summary>
+    ///  The token to use for requests that require authentication
+    /// </summary>
+    public string? ModrinthToken { get; set; }
+
+    /// <summary>
+    ///  The base URL to use for requests, you don't need to change this unless you want to use a different instance of Modrinth (e.g. a staging server)
+    ///  Default is <see cref="ModrinthClient.BaseUrl"/>
+    /// </summary>
+    public string BaseUrl { get; set; } = ModrinthClient.BaseUrl;
+    /// <summary>
+    /// User-Agent you want to use while communicating with Modrinth API, it's recommended to
+    /// set a uniquely-identifying one (<a href="https://docs.modrinth.com/api-spec/#section/User-Agents">see the docs</a>)
+    /// </summary>
+    public string UserAgent { get; set; } = $"Modrinth.Net/{Assembly.GetExecutingAssembly().GetName().Version}";
+
+    /// <summary>
+    ///   The number of times to retry a request if the rate limit is hit
+    /// </summary>
+    public int RateLimitRetryCount { get; set; } = 5;
+    
+    
+}

--- a/Modrinth.Net/ModrinthClientConfiguration.cs
+++ b/Modrinth.Net/ModrinthClientConfiguration.cs
@@ -1,30 +1,30 @@
-﻿using System.Reflection;
-
-namespace Modrinth;
+﻿namespace Modrinth;
 
 /// <summary>
-///    Object containing configuration for <see cref="ModrinthClient"/>
+///     Object containing configuration for <see cref="ModrinthClient" />
 /// </summary>
 public class ModrinthClientConfiguration
 {
     /// <summary>
-    ///  The token to use for requests that require authentication
+    ///     The token to use for requests that require authentication
     /// </summary>
     public string? ModrinthToken { get; set; }
 
     /// <summary>
-    ///  The base URL to use for requests, you don't need to change this unless you want to use a different instance of Modrinth (e.g. a staging server)
-    ///  Default is <see cref="ModrinthClient.BaseUrl"/>
+    ///     The base URL to use for requests, you don't need to change this unless you want to use a different instance of
+    ///     Modrinth (e.g. a staging server)
+    ///     Default is <see cref="ModrinthClient.BaseUrl" />
     /// </summary>
     public string BaseUrl { get; set; } = ModrinthClient.BaseUrl;
-    /// <summary>
-    /// User-Agent you want to use while communicating with Modrinth API, it's recommended to
-    /// set a uniquely-identifying one (<a href="https://docs.modrinth.com/api-spec/#section/User-Agents">see the docs</a>)
-    /// </summary>
-    public string UserAgent { get; set; } = $"Modrinth.Net/{ PackageVersion.GetVersion() }";
 
     /// <summary>
-    ///   The number of times to retry a request if the rate limit is hit
+    ///     User-Agent you want to use while communicating with Modrinth API, it's recommended to
+    ///     set a uniquely-identifying one (<a href="https://docs.modrinth.com/api-spec/#section/User-Agents">see the docs</a>)
+    /// </summary>
+    public string UserAgent { get; set; } = $"Modrinth.Net/{PackageVersion.GetVersion()}";
+
+    /// <summary>
+    ///     The number of times to retry a request if the rate limit is hit
     /// </summary>
     public int RateLimitRetryCount { get; set; } = 5;
 }

--- a/Modrinth.Net/PackageVersion.cs
+++ b/Modrinth.Net/PackageVersion.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+
+namespace Modrinth;
+
+internal static class PackageVersion
+{
+    public static string GetVersion()
+    {
+        var assembly = Assembly.GetAssembly(typeof(PackageVersion));
+
+        if (assembly == null)
+            return "";
+        
+        var assemblyName = AssemblyName.GetAssemblyName(assembly.Location);
+        
+        if (assemblyName.Version == null)
+            return "";
+        
+        return assemblyName.Version.ToString();
+    }
+}

--- a/Modrinth.Net/PackageVersion.cs
+++ b/Modrinth.Net/PackageVersion.cs
@@ -10,12 +10,12 @@ internal static class PackageVersion
 
         if (assembly == null)
             return "";
-        
+
         var assemblyName = AssemblyName.GetAssemblyName(assembly.Location);
-        
+
         if (assemblyName.Version == null)
             return "";
-        
+
         return assemblyName.Version.ToString();
     }
 }


### PR DESCRIPTION
Add ModrinthClientConfiguration for better settings up the client, also sets a default User-Agent based on the library name and version

Old constructors are still there, but marked as obsolete