### PR TITLE
Fixed searching when query has spaces

### DIFF
--- a/src/Modrinth.Net/Endpoints/Project/ProjectEndpoint.cs
+++ b/src/Modrinth.Net/Endpoints/Project/ProjectEndpoint.cs
@@ -230,7 +230,7 @@ public class ProjectEndpoint : Endpoint, IProjectEndpoint
 
         var parameters = new ParameterBuilder
         {
-            {"query", query.EscapeIfContains()},
+            {"query", query.Replace(' ', '_')},
             {"index", index.ToString().ToLower()},
             {"offset", offset},
             {"limit", limit}

--- a/test/Modrinth.Net.Test/ModrinthApiTests/SearchTests.cs
+++ b/test/Modrinth.Net.Test/ModrinthApiTests/SearchTests.cs
@@ -168,4 +168,22 @@ public class SearchTests : EndpointTests
         // Check that every search result has the adventure and cursed category
         Assert.That(search.Hits.Select(p => p.Categories).All(c => c.Contains("adventure") && c.Contains("cursed")));
     }
+
+    [Test]
+    public async Task Search_PopularModWithSpacesInName_ShouldReturnMultipleResults()
+    {
+        string[] testedMods = new string[] 
+        { 
+            "industrial craft 2",
+            "divine rpg",
+            "just enough items",
+            "better biomes"
+        };
+        
+        foreach(var mod in testedMods)
+        {
+            var result = await Client.Project.SearchAsync(mod);
+            Assert.That(result.TotalHits, Is.GreaterThan(3)); // query="just enough items" returns 3 results, query=just_enough_items returns a lot
+        }
+    }
 }


### PR DESCRIPTION
If query text had a space in it, the query was escaped by double quotes ("), which yielded incorrect results (my guess is it only returned projects which had *exact* copy of the text in quotes, like search engines often do). By replacing spaces with underscores (' ' => '_') I got the correct results (which mirrored search on modrinth website), so I changed this behavior here and created a test for it (which is more of a demonstration tbh)