### PR TITLE
Requests could throw HttpRequestException instead of ModrinthApiException

### DIFF
--- a/src/Modrinth.Net/Exceptions/ModrinthApiException.cs
+++ b/src/Modrinth.Net/Exceptions/ModrinthApiException.cs
@@ -15,7 +15,7 @@ public class ModrinthApiException : Exception
     /// <param name="response"> The HTTP response message. </param>
     /// <param name="error"> The error returned by the Modrinth API. </param>
     /// <param name="innerException"> The inner exception. </param>
-    public ModrinthApiException(string message, HttpResponseMessage response,
+    public ModrinthApiException(string message, HttpResponseMessage? response = null,
         ResponseError? error = null, Exception? innerException = null) : base(message, innerException)
     {
         Error = error;
@@ -23,21 +23,9 @@ public class ModrinthApiException : Exception
     }
 
     /// <summary>
-    ///     The status code of the HTTP response.
-    /// </summary>
-    [Obsolete("Use Response.StatusCode instead. This property will be removed in a future version of the API.")]
-    public HttpStatusCode StatusCode => Response.StatusCode;
-
-    /// <summary>
-    ///     The HTTP response content.
-    /// </summary>
-    [Obsolete("Use Response.Content instead. This property will be removed in a future version of the API.")]
-    public HttpContent Content => Response.Content;
-
-    /// <summary>
     ///     The HTTP response message.
     /// </summary>
-    public HttpResponseMessage Response { get; }
+    public HttpResponseMessage? Response { get; }
 
     /// <summary>
     ///     The error returned by the Modrinth API.

--- a/src/Modrinth.Net/Http/Requester.cs
+++ b/src/Modrinth.Net/Http/Requester.cs
@@ -104,7 +104,15 @@ public class Requester : IRequester
         var retryCount = 0;
         while (true)
         {
-            var response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            HttpResponseMessage response;
+            try
+            {
+                response = await HttpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+            catch (HttpRequestException e)
+            {
+                throw new ModrinthApiException("An error occurred while sending the request.", innerException: e);
+            }
 
             if (response.IsSuccessStatusCode) return response;
 

--- a/test/Modrinth.Net.Test/Modrinth.Net.Test.csproj
+++ b/test/Modrinth.Net.Test/Modrinth.Net.Test.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="NUnit" Version="4.0.1"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
         <PackageReference Include="NUnit.Analyzers" Version="4.0.1">

--- a/test/Modrinth.Net.Test/RequesterTests.cs
+++ b/test/Modrinth.Net.Test/RequesterTests.cs
@@ -1,0 +1,31 @@
+using Modrinth.Exceptions;
+using Modrinth.Http;
+
+namespace Modrinth.Net.Test;
+
+[TestFixture]
+public class RequesterTests
+{
+    [Test]
+    public void Requester_ShouldNotThrow_HttpException()
+    {
+        // Arrange
+        var mockHttpClient = new Mock<HttpClient>();
+        mockHttpClient.Setup(client => client.SendAsync(It.IsAny<HttpRequestMessage>(), It.IsAny<CancellationToken>()))
+            .Throws(new HttpRequestException("An error occurred while sending the request."));
+
+        var config = new ModrinthClientConfig
+        {
+            BaseUrl = "http://test.com",
+            UserAgent = "TestAgent",
+            ModrinthToken = "TestToken"
+        };
+
+        var requester = new Requester(config, mockHttpClient.Object);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://test.com");
+        
+        Assert.ThrowsAsync<ModrinthApiException>(async () => await requester.GetJsonAsync<object>(request));
+    }
+
+}

--- a/test/Modrinth.Net.Test/Usings.cs
+++ b/test/Modrinth.Net.Test/Usings.cs
@@ -1,1 +1,2 @@
 global using NUnit.Framework;
+global using Moq;


### PR DESCRIPTION
This makes sure that even when no connectivity and other problems, the library always throws ModrinthApiException