### PR TITLE
Fixed small typo in ProjectStatus

### DIFF
--- a/src/Modrinth.Net/Models/Enums/Project/ProjectStatus.cs
+++ b/src/Modrinth.Net/Models/Enums/Project/ProjectStatus.cs
@@ -41,9 +41,9 @@ public enum ProjectStatus
     Unknown,
     
     /// <summary>
-    ///     Project is witheld
+    ///     Project is withheld
     /// </summary>
-    Witheld,
+    Withheld,
     
     /// <summary>
     ///     Project is scheduled for release


### PR DESCRIPTION
Pretty much what the title says, it was just messing with the json serializer on withheld projects 