### PR TITLE
Fix field FileName in model File always null

### DIFF
--- a/src/Modrinth.Net/Models/File.cs
+++ b/src/Modrinth.Net/Models/File.cs
@@ -23,7 +23,7 @@ public class File
     /// <summary>
     ///     The name of the file
     /// </summary>
-    public string FileName { get; set; }
+    [JsonPropertyName("filename")] public string FileName { get; set; }
 
     /// <summary>
     ///     Whether the file is the primary file of the version

--- a/test/Modrinth.Net.Test/ModrinthApiTests/EndpointTests.cs
+++ b/test/Modrinth.Net.Test/ModrinthApiTests/EndpointTests.cs
@@ -19,6 +19,12 @@ public class EndpointTests
     protected static readonly string[] ValidSha1Hashes =
         {"43035a1c6f506285a9910bc8038d1b1b925f8dd1", "2f73c4a26c553bf0f0d2f921dd5a09ed90c515d8"};
 
+    protected static readonly string[] ValidFileName =
+    {
+        "fabric-api-0.102.0+1.21.jar",
+        "sodium-fabric-0.5.8+mc1.20.6.jar"
+    };
+
     private static readonly IConfigurationRoot Configuration =
         new ConfigurationBuilder().AddJsonFile("appsettings.json").Build();
 

--- a/test/Modrinth.Net.Test/ModrinthApiTests/VersionFileTests.cs
+++ b/test/Modrinth.Net.Test/ModrinthApiTests/VersionFileTests.cs
@@ -40,6 +40,23 @@ public class VersionFileTests : EndpointTests
     }
 
     [Test]
+    [TestCase(0)]
+    [TestCase(1)]
+    public async Task EnsureFileNameSerializationCorrect(int index)
+    {
+        var hash = ValidSha1Hashes[index];
+        var fileName = ValidFileName[index];
+
+        var version = await Client.VersionFile.GetVersionByHashAsync(hash);
+
+        Assert.That(version, Is.Not.Null);
+
+        var file = version.Files.FirstOrDefault(f => f.Hashes.Sha1 == hash && f.FileName == fileName);
+        
+        Assert.That(file, Is.Not.Null);
+    }
+
+    [Test]
     public async Task GetMultipleVersionsFromHashesSha1()
     {
         var hashes = ValidSha1Hashes;


### PR DESCRIPTION
expression `file.Files[0].FileName` is null
![snapshot1](https://github.com/user-attachments/assets/87ddeff1-d00f-465c-a065-e28bf8fb5826)

but on modrinth, it's not null
![snapshot2](https://github.com/user-attachments/assets/4197ca1a-afb9-4e83-9a34-333f2cc4a663)

because System.Json.Text serialize `FileName` as `fileName` but not `filename`