### PR TITLE
Fix/aot compatibility

### DIFF
--- a/src/Modrinth.Net/Http/Requester.cs
+++ b/src/Modrinth.Net/Http/Requester.cs
@@ -34,6 +34,8 @@ public class Requester : IRequester
     public Requester(ModrinthClientConfig config, HttpClient? httpClient = null)
     {
         _config = config;
+        if (config.JsonSerializerContext != null)
+            _jsonSerializerOptions.TypeInfoResolverChain.Add(config.JsonSerializerContext);
         _semaphore = new SemaphoreSlim(_config.MaxConcurrentRequests);
 
         HttpClient = httpClient ?? new HttpClient();

--- a/src/Modrinth.Net/ModrinthClientConfig.cs
+++ b/src/Modrinth.Net/ModrinthClientConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Modrinth;
+﻿using System.Text.Json.Serialization.Metadata;
+
+namespace Modrinth;
 
 /// <summary>
 ///     Object containing options for <see cref="ModrinthClient" />
@@ -41,6 +43,12 @@ public class ModrinthClientConfig
     ///     Default is 100.
     /// </summary>
     public int BatchSize { get; set; } = 100;
+    
+    /// <summary>
+    ///     The JSON serializer context to use for serialization and deserialization.
+    ///     If null, the client will use the default serializer with reflection-based serialization, which is less performant.
+    /// </summary>
+    public IJsonTypeInfoResolver? JsonSerializerContext { get; set; }
 
     /// <summary>
     ///     Validates the configuration options.


### PR DESCRIPTION
I have added an IJsonTypeInfoResolver? to the client's configuration. This fixes some issues when AOT is enabled, without it the json serializer throws exceptions.